### PR TITLE
Add basic web frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Run the server:
 python controller.py
 ```
 Send REST commands to http://localhost:8000.
+
+## Web UI
+A small static web interface is available after starting the server.
+Open `http://localhost:8000/ui/` in your browser to add devices,
+create groups and set colors via forms.

--- a/controller.py
+++ b/controller.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
 import uvicorn
 from pydantic import BaseModel
 import paho.mqtt.client as mqtt
@@ -60,6 +61,7 @@ class Controller:
 
 controller = Controller()
 app = FastAPI()
+app.mount("/ui", StaticFiles(directory="static", html=True), name="static")
 
 
 class DeviceModel(BaseModel):

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,55 @@
+async function api(url, method, data) {
+    const res = await fetch(url, {
+        method: method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+    });
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text);
+    }
+    return res.json();
+}
+
+document.getElementById('device-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+        await api('/devices', 'POST', {
+            name: document.getElementById('device-name').value,
+            ip: document.getElementById('device-ip').value,
+            pixels: parseInt(document.getElementById('device-pixels').value)
+        });
+        alert('Device added');
+    } catch (err) {
+        alert('Error adding device: ' + err.message);
+    }
+});
+
+document.getElementById('group-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+        const names = document.getElementById('group-devices').value.split(',').map(s => s.trim());
+        await api('/groups', 'POST', {
+            name: document.getElementById('group-name').value,
+            devices: names
+        });
+        alert('Group added');
+    } catch (err) {
+        alert('Error adding group: ' + err.message);
+    }
+});
+
+document.getElementById('color-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+        await api('/color', 'POST', {
+            group: document.getElementById('color-group').value,
+            r: parseInt(document.getElementById('color-r').value),
+            g: parseInt(document.getElementById('color-g').value),
+            b: parseInt(document.getElementById('color-b').value)
+        });
+        alert('Color set');
+    } catch (err) {
+        alert('Error setting color: ' + err.message);
+    }
+});

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Calamaro Controller</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Calamaro Controller</h1>
+
+    <section>
+        <h2>Add Device</h2>
+        <form id="device-form">
+            <input type="text" id="device-name" placeholder="Name" required>
+            <input type="text" id="device-ip" placeholder="IP" required>
+            <input type="number" id="device-pixels" placeholder="Pixels" required>
+            <button type="submit">Add</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Add Group</h2>
+        <form id="group-form">
+            <input type="text" id="group-name" placeholder="Name" required>
+            <input type="text" id="group-devices" placeholder="Device names comma separated" required>
+            <button type="submit">Add</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Set Color</h2>
+        <form id="color-form">
+            <input type="text" id="color-group" placeholder="Group" required>
+            <input type="number" id="color-r" placeholder="R" min="0" max="255" required>
+            <input type="number" id="color-g" placeholder="G" min="0" max="255" required>
+            <input type="number" id="color-b" placeholder="B" min="0" max="255" required>
+            <button type="submit">Set</button>
+        </form>
+    </section>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,12 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+section {
+    margin-bottom: 2rem;
+}
+input {
+    margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- serve a minimal UI from `/ui`
- implement forms in static `index.html`
- add JS helpers to call the API endpoints
- add simple styling
- document the web UI usage

## Testing
- `python -m pip install -r requirements.txt`
- `python controller.py` *(server start)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7d12c82c8332a16a3fad952220fd