### PR TITLE
Fix DMX channel start index

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -56,7 +56,9 @@ class Controller:
             raise ValueError(f"Group {group} not defined")
         for device in self.groups[group].devices:
             universe = self.universes[device.name]
-            ch = universe.add_channel(0, device.pixels * 3, 'uint8')
+            # DMX channel indexing starts at 1. Using 0 causes a
+            # ChannelOutOfUniverseError in pyartnet.
+            ch = universe.add_channel(1, device.pixels * 3, 'uint8')
             await ch.add_fade([r, g, b] * device.pixels, 0)
 
 


### PR DESCRIPTION
## Summary
- fix internal server error when setting color by using DMX start index 1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea43358448332b31ddda0ddff4742